### PR TITLE
Untitled

### DIFF
--- a/js/jquery.ui.carousel.js
+++ b/js/jquery.ui.carousel.js
@@ -30,7 +30,7 @@
 
 	$.widget('ui.carousel', {
 	
-		version: 0.5.1,
+		version: '0.5.1',
 		
 		// holds original class string
 		oldClass: null,


### PR DESCRIPTION
Looks like 0.5.1 is being treated as a string in safari causing a syntax error.  Quoting it allows for the demo to work.
