### PR TITLE
autoscrol clean time on pagination bug fix

### DIFF
--- a/js/jquery.rs.carousel-autoscroll.js
+++ b/js/jquery.rs.carousel-autoscroll.js
@@ -36,10 +36,15 @@
             
             this._bindAutoScroll();
             this._start();
-            
+            this._paginatioCleanTime();
             return;
         },
-        
+        _paginatioCleanTime: function() {
+          var pagLoc = $('body').find('.rs-carousel-pagination');
+          pagLoc.find('li')
+            .bind('click.' + this.widgetName, $.proxy(this, '_stop'))
+            .bind('click.' + this.widgetName, $.proxy(this, '_start'));
+        },
         _bindAutoScroll: function() {
             
             if (this.autoScrollInitiated) {


### PR DESCRIPTION
Added function _paginatioCleanTime to fix issue with clean time with pagination.
when click on page in pagination and slider slide time on autoscroll donesn't reset . this function reset this time to 0 and start time-in again.
