### PR TITLE
Disable both the left and right buttons when the widget is disabled.

### DIFF
--- a/js/jquery.rs.carousel.js
+++ b/js/jquery.rs.carousel.js
@@ -616,14 +616,16 @@ undef: true, unused: true, strict: true, trailing: true, browser: true */
                     .removeClass(disabledClass);
 
             if (!this.options.loop) {
-                
-                if (index === this.getNoOfPages() - 1) {
+                if (this.options.disabled) {
+                    elems.nextAction
+                        .add(elems.prevAction)
+                             .addClass(disabledClass);
+                } else if (index === this.getNoOfPages() - 1) {
                     elems.nextAction.addClass(disabledClass);
                 }
                 else if (index === 0) {
                     elems.prevAction.addClass(disabledClass);
                 }
-
             }
 
             return;


### PR DESCRIPTION
When the app is in a disabled state, and external left/right buttons are added using the 'insertPrevAction' and 'insertNextAction' methods, the 'Prev' button remains enabled.

:) This fixes that!
